### PR TITLE
Fix byte compilation in utop-choose

### DIFF
--- a/src/top/utop.el
+++ b/src/top/utop.el
@@ -759,7 +759,8 @@ when byte-compiling."
     (intern (concat "typerex-" symbol)))
    ((require 'caml nil t)
     (intern (concat "caml-" symbol)))
-   (error (concat "unsupported mode: " (symbol-name major-mode) ", utop support only caml, tuareg and typerex modes"))))
+   (t (error "Unsupported mode: %S, utop supports only caml, tuareg and typerex modes"
+             major-mode))))
 
 (defmacro utop-choose-symbol (symbol)
   (utop-choose symbol))

--- a/src/top/utop.el
+++ b/src/top/utop.el
@@ -743,24 +743,25 @@ If ADD-TO-HISTORY is t then the input will be added to history."
 ;; | Caml/Tuareg/Typerex integration                                 |
 ;; +-----------------------------------------------------------------+
 
-(defun utop-choose (symbol)
-  "Be best at resolving caml, tuareg or typerex dependencies even
+(eval-and-compile
+  (defun utop-choose (symbol)
+    "Be best at resolving caml, tuareg or typerex dependencies even
 when byte-compiling."
-  (cond
-   ((eq major-mode 'tuareg-mode)
-    (intern (concat "tuareg-" symbol)))
-   ((eq major-mode 'typerex-mode)
-    (intern (concat "typerex-" symbol)))
-   ((eq major-mode 'caml-mode)
-    (intern (concat "caml-" symbol)))
-   ((require 'tuareg nil t)
-    (intern (concat "tuareg-" symbol)))
-   ((require 'typerex nil t)
-    (intern (concat "typerex-" symbol)))
-   ((require 'caml nil t)
-    (intern (concat "caml-" symbol)))
-   (t (error "Unsupported mode: %S, utop supports only caml, tuareg and typerex modes"
-             major-mode))))
+    (cond
+     ((eq major-mode 'tuareg-mode)
+      (intern (concat "tuareg-" symbol)))
+     ((eq major-mode 'typerex-mode)
+      (intern (concat "typerex-" symbol)))
+     ((eq major-mode 'caml-mode)
+      (intern (concat "caml-" symbol)))
+     ((require 'tuareg nil t)
+      (intern (concat "tuareg-" symbol)))
+     ((require 'typerex nil t)
+      (intern (concat "typerex-" symbol)))
+     ((require 'caml nil t)
+      (intern (concat "caml-" symbol)))
+     (t (error "Unsupported mode: %S, utop supports only caml, tuareg and typerex modes"
+               major-mode)))))
 
 (defmacro utop-choose-symbol (symbol)
   (utop-choose symbol))


### PR DESCRIPTION
Fix the flawed `cond` branch to correctly signal an error for unsupported modes, and wrap `utop-choose` in `eval-and-compile` to make it available at macro expansion time.

This whole `utop-choose` thing looks really scary.  What problem is it even supposed to solve?