### PR TITLE
Refactor major mode use

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ utop also ships with a minor mode that has the following key-bindings
 
 | key-binding | function          | Description                  |
 |-------------|-------------------|------------------------------|
-| C-c C-z     | utop              | Start a utop buffer          |
+| C-c C-s     | utop              | Start a utop buffer          |
 | C-x C-e     | utop-eval-phrase  | Evaluate the current phrase  |
 | C-x C-r     | utop-eval-region  | Evaluate the selected region |
 | C-c C-b     | utop-eval-buffer  | Evaluate the current buffer  |
@@ -158,9 +158,6 @@ e.g. typerex, then you will need the following configuration instead
 
 ```scheme
 (autoload 'utop-minor-mode "utop" "Minor mode for utop" t)
-(setq utop-skip-blank-and-comments 'typerex-skip-blank-and-comments)
-(setq utop-skip-to-end-of-phrase 'typerex-skip-to-end-of-phrase)
-(setq utop-discover-phrase 'typerex-discover-phrase)
 (add-hook 'typerex-mode-hook 'utop-minor-mode)
 ```
 

--- a/README.md
+++ b/README.md
@@ -135,21 +135,38 @@ you can copy-paste this code into you `~/.emacs` file:
 
 Then you can execute utop inside emacs with: `M-x utop`.
 
-Integration with the tuareg/typerex mode
-----------------------------------------
+utop also ships with a minor mode that has the following key-bindings
 
-You can replace the default toplevel used by the tuareg or typerex
-mode by utop, for that add the following lines to your `~/.emacs` file:
+| key-binding | function          | Description                  |
+|-------------|-------------------|------------------------------|
+| C-c C-z     | utop              | Start a utop buffer          |
+| C-x C-e     | utop-eval-phrase  | Evaluate the current phrase  |
+| C-x C-r     | utop-eval-region  | Evaluate the selected region |
+| C-c C-b     | utop-eval-buffer  | Evaluate the current buffer  |
+| C-c C-k     | utop-kill         | Kill a running utop process  |
+
+You can enable the minor mode using `M-x utop-minor-mode`, or you can
+have it enabled by default with the following configuration
 
 ```scheme
-(autoload 'utop-setup-ocaml-buffer "utop" "Toplevel for OCaml" t)
-(add-hook 'tuareg-mode-hook 'utop-setup-ocaml-buffer)
-(add-hook 'typerex-mode-hook 'utop-setup-ocaml-buffer)
+(autoload 'utop-minor-mode "utop" "Minor mode for utop" t)
+(add-hook 'tuareg-mode-hook 'utop-minor-mode)
 ```
 
-You can also complete text in a tuareg or typerex buffer using the
-environment of the toplevel. For that bind the function
-`utop-edit-complete` to the key you want.
+If you plan to use utop with another major-mode than tuareg,
+e.g. typerex, then you will need the following configuration instead
+
+```scheme
+(autoload 'utop-minor-mode "utop" "Minor mode for utop" t)
+(setq utop-skip-blank-and-comments 'typerex-skip-blank-and-comments)
+(setq utop-skip-to-end-of-phrase 'typerex-skip-to-end-of-phrase)
+(setq utop-discover-phrase 'typerex-discover-phrase)
+(add-hook 'typerex-mode-hook 'utop-minor-mode)
+```
+
+You can also complete text in a buffer using the environment of the
+toplevel. For that bind the function `utop-edit-complete` to the key
+you want.
 
 Common error
 ------------

--- a/src/top/utop.el
+++ b/src/top/utop.el
@@ -217,13 +217,13 @@ Useful as file variable."))
    "Name of preprocesor. Currently supported camlp4o, camlp4r.
 Useful as file variable."))
 
-(defvar utop-skip-blank-and-comments 'tuareg-skip-blank-and-comments
+(defvar utop-skip-blank-and-comments 'compat-skip-blank-and-comments
   "The function used to skip blanks and comments.")
 
-(defvar utop-skip-to-end-of-phrase 'tuareg-skip-to-end-of-phrase
+(defvar utop-skip-to-end-of-phrase 'compat-skip-to-end-of-phrase
   "The function used to find the end of a phrase")
 
-(defvar utop-discover-phrase 'tuareg-discover-phrase
+(defvar utop-discover-phrase 'compat-discover-phrase
   "The function used to discover a phrase")
 
 (defvar utop-skip-after-eval-phrase t
@@ -233,7 +233,37 @@ Non-nil means skip to the end of the phrase after evaluation in the
 Caml toplevel")
 
 ;; +-----------------------------------------------------------------+
-;; | Compability                                                     |
+;; | Compability with different ocaml major modes                    |
+;; +-----------------------------------------------------------------+
+
+(defun utop-compat-resolve (symbol)
+  "Resolve a symbol based on the current major mode."
+  (cond
+   ((eq major-mode 'tuareg-mode)
+    (intern (concat "tuareg-" symbol)))
+   ((eq major-mode 'typerex-mode)
+    (intern (concat "typerex-" symbol)))
+   ((eq major-mode 'caml-mode)
+    (intern (concat "caml-" symbol)))
+   ((require 'tuareg nil t)
+    (intern (concat "tuareg-" symbol)))
+   ((require 'typerex nil t)
+    (intern (concat "typerex-" symbol)))
+   ((require 'caml nil t)
+    (intern (concat "caml-" symbol)))
+   (error (concat "unsupported mode: " (symbol-name major-mode) ", utop support only caml, tuareg and typerex modes"))))
+
+(defun compat-skip-blank-and-comments ()
+  (funcall (utop-compat-resolve "skip-blank-and-comments")))
+
+(defun compat-skip-to-end-of-phrase ()
+  (funcall (utop-compat-resolve "skip-to-end-of-phrase")))
+
+(defun compat-discover-phrase ()
+  (funcall (utop-compat-resolve "discover-phrase")))
+
+;; +-----------------------------------------------------------------+
+;; | Compability with previous emacs version                         |
 ;; +-----------------------------------------------------------------+
 
 (unless (featurep 'tabulated-list)
@@ -1115,12 +1145,16 @@ defaults to 0."
     (utop-insert "\nRestarting...\n\n")
     (utop-start arguments)))
 
+(defun utop-setup-ocaml-buffer ()
+  "Deprecated"
+  (error "This function is deprecated. See https://github.com/diml/utop for configuration information."))
+
 ;;;###autoload
 (define-minor-mode utop-minor-mode
   "Minor mode for utop."
   :lighter " utop"
   :keymap (let ((map (make-sparse-keymap)))
-            (define-key map (kbd "C-c C-z") 'utop)
+            (define-key map (kbd "C-c C-s") 'utop)
             (define-key map (kbd "C-x C-e") 'utop-eval-phrase)
             (define-key map (kbd "C-x C-r") 'utop-eval-region)
             (define-key map (kbd "C-c C-b") 'utop-eval-buffer)

--- a/src/top/utop.el
+++ b/src/top/utop.el
@@ -1115,6 +1115,7 @@ defaults to 0."
     (utop-insert "\nRestarting...\n\n")
     (utop-start arguments)))
 
+;;;###autoload
 (define-minor-mode utop-minor-mode
   "Minor mode for utop."
   :lighter " utop"
@@ -1128,6 +1129,7 @@ defaults to 0."
   ;; Load local file variables
   (add-hook 'hack-local-variables-hook 'utop-hack-local-variables))
 
+;;;###autoload
 (define-derived-mode utop-mode fundamental-mode "utop"
   "Set the buffer mode to utop."
 
@@ -1203,6 +1205,7 @@ Special keys for utop:
         (with-current-buffer buf (utop-mode)))))
   buf))
 
+(provide 'utop-minor-mode)
 (provide 'utop)
 
 ;;; utop.el ends here

--- a/src/top/utop.el
+++ b/src/top/utop.el
@@ -207,13 +207,15 @@ before the end of prompt.")
   "The position of the cursor in the phrase sent to OCaml (where
 to add the newline character if it is not accepted).")
 
-(defvar utop-package-list nil
-  "List of packages to load when visiting OCaml buffer.
-Useful as file variable.")
+(make-variable-buffer-local
+ (defvar utop-package-list nil
+   "List of packages to load when visiting OCaml buffer.
+Useful as file variable."))
 
-(defvar utop-ocaml-preprocessor nil
-  "Name of preprocesor. Currently supported camlp4o, camlp4r.
-Useful as file variable.")
+(make-variable-buffer-local
+ (defvar utop-ocaml-preprocessor nil
+   "Name of preprocesor. Currently supported camlp4o, camlp4r.
+Useful as file variable."))
 
 ;; +-----------------------------------------------------------------+
 ;; | Compability                                                     |
@@ -881,42 +883,6 @@ when byte-compiling."
             ;; Send the phrase to complete
             (utop-complete-input input)))))))
 
-(defun utop-setup-ocaml-buffer ()
-  "Override caml/tuareg/typerex interactive functions by utop ones.
-
-You can call this function after loading the caml/tuareg/typerex
-mode to let it use utop instead of its builtin support for
-interactive toplevel.
-
-To automatically do that just add these lines to your .emacs:
-
-  (autoload 'utop-setup-ocaml-buffer \"utop\" \"Toplevel for OCaml\" t)
-  (add-hook 'caml-mode-hook 'utop-setup-ocaml-buffer)
-  (add-hook 'tuareg-mode-hook 'utop-setup-ocaml-buffer)
-  (add-hook 'typerex-mode-hook 'utop-setup-ocaml-buffer)"
-  (interactive)
-  ;; Redefine caml/tuareg/typerex functions
-  (utop-choose-defun "eval-phrase" () (interactive) (utop-eval-phrase))
-  (utop-choose-defun "eval-region" (start end) (interactive "r") (utop-eval-region start end))
-  (utop-choose-defun "eval-buffer" () (interactive) (utop-eval-buffer))
-  (utop-choose-defun "interrupt-caml" () (interactive) (utop-interrupt))
-  (utop-choose-defun "kill-caml" () (interactive) (utop-kill))
-  (utop-choose-defun "run-caml" () (interactive) (utop))
-
-  ;; Redefine this variable so menu will work
-  (set (utop-choose "interactive-buffer-name") utop-buffer-name)
-
-  ;; Package list for this file
-  (make-local-variable 'utop-package-list)
-
-  ;; Preprocessor to use
-  (make-local-variable 'utop-ocaml-preprocessor)
-
-  ;; Load local file variables
-  (add-hook 'hack-local-variables-hook 'utop-hack-local-variables)
-
-  nil)
-
 ;; +-----------------------------------------------------------------+
 ;; | Edition functions                                               |
 ;; +-----------------------------------------------------------------+
@@ -1163,6 +1129,19 @@ defaults to 0."
     (goto-char (point-max))
     (utop-insert "\nRestarting...\n\n")
     (utop-start arguments)))
+
+(define-minor-mode utop-minor-mode
+  "Minor mode for utop."
+  :lighter " utop"
+  :keymap (let ((map (make-sparse-keymap)))
+            (define-key map (kbd "C-c C-z") 'utop)
+            (define-key map (kbd "C-x C-e") 'utop-eval-phrase)
+            (define-key map (kbd "C-x C-r") 'utop-eval-region)
+            (define-key map (kbd "C-c C-b") 'utop-eval-buffer)
+            (define-key map (kbd "C-c C-k") 'utop-kill)
+            map)
+  ;; Load local file variables
+  (add-hook 'hack-local-variables-hook 'utop-hack-local-variables))
 
 (define-derived-mode utop-mode fundamental-mode "utop"
   "Set the buffer mode to utop."


### PR DESCRIPTION
These changes were sparked by the discussion on #87.

Additionally I was hitting a bug when using the babel feature in org-mode. The previous implementation would mess with the `*-interactive-buffer-name` variable which stopped babel from being able to evaluate my OCaml code in my code blocks.

Please note that this is a breaking-change for emacs users as they will need to change their configuration given that `utop-setup-ocaml-buffer` has been deleted.