### PR TITLE
Fix non-exist function

### DIFF
--- a/src/top/utop.el
+++ b/src/top/utop.el
@@ -409,8 +409,8 @@ it is started."
     (save-excursion
       (goto-char utop-prompt-min)
       (forward-line -1)
-      (let ((line (replace-in-string (thing-at-point 'line) "\n" "")))
-        (set-text-properties 0 (length line) nil line)
+      (let ((line (buffer-substring-no-properties
+                   (line-beginning-position) (line-end-position))))
         (message line)))))
 
 ;; Poor man's identifier at point


### PR DESCRIPTION
Emacs does not have 'replace-in-string' function. You can see this by byte-compiling.

```
In end of data:
utop.el:1258:1:Warning: the function `replace-in-string' is not known to be defined.
```