### PR TITLE
Stashing

### DIFF
--- a/src/lib/uTop.cppo.ml
+++ b/src/lib/uTop.cppo.ml
@@ -636,8 +636,7 @@ let () =
       (fun fname ->
         let _ :: entries = LTerm_history.contents stashable_session_history in
         (* getting and then reversing the entries instead of using
-         * [LTerm_history.save] because the latter has to be integrated
-         * into an LWT program flow. *)
+           [LTerm_history.save] because the latter escapes newline characters *)
         let () =
           Printf.printf
             "Stashing %d entries in %s... "
@@ -648,12 +647,10 @@ let () =
         try
           let oc = open_out fname in
           try
-            let ls = ref entries in
-            for i = 1 to List.length entries do
-              let e :: _ = !ls in
-              let () = output_string oc (e ^ "\n") in
-              ls := List.tl !ls;
-            done;
+            List.iter
+              (fun e ->
+                output_string oc (e ^ "\n"))
+              entries;
             close_out oc;
             Printf.printf "Done.\n";
           with exn ->

--- a/src/lib/uTop.cppo.ml
+++ b/src/lib/uTop.cppo.ml
@@ -27,6 +27,11 @@ let history = LTerm_history.create []
 let history_file_name = ref (Some (Filename.concat LTerm_resources.home ".utop-history"))
 let history_file_max_size = ref None
 let history_file_max_entries = ref None
+let stashable_session_history =
+  (LTerm_history.create
+    ~max_size:max_int
+    ~max_entries:max_int
+    [])
 
 (* +-----------------------------------------------------------------+
    | Hooks                                                           |
@@ -532,6 +537,7 @@ utop defines the following directives:
 
 #utop_bindings   : list all the current key bindings
 #utop_macro      : display the currently recorded macro
+#utop_stash      : store all the valid commands from your current session in a file
 #topfind_log     : display messages recorded from findlib since the beginning of the session
 #topfind_verbose : enable/disable topfind verbosity
 
@@ -623,6 +629,37 @@ let () =
   Hashtbl.add Toploop.directive_table "pwd"
     (Toploop.Directive_none
        (fun () -> print_endline (Sys.getcwd ())))
+
+let () =
+  Hashtbl.add Toploop.directive_table "utop_stash"
+    (Toploop.Directive_string
+      (fun fname ->
+        let _ :: entries = LTerm_history.contents stashable_session_history in
+        (* getting and then reversing the entries instead of using
+         * [LTerm_history.save] because the latter has to be integrated
+         * into an LWT program flow. *)
+        let () =
+          Printf.printf
+            "Stashing %d entries in %s... "
+            (List.length entries)
+            fname
+        in
+        let entries = List.rev entries in
+        try
+          let oc = open_out fname in
+          try
+            let ls = ref entries in
+            for i = 1 to List.length entries do
+              let e :: _ = !ls in
+              let () = output_string oc (e ^ "\n") in
+              ls := List.tl !ls;
+            done;
+            close_out oc;
+            Printf.printf "Done.\n";
+          with exn ->
+            close_out oc;
+            Printf.printf "Done.\n";
+        with exn -> Printf.printf "Error with file %s.\n" fname))
 
 (* +-----------------------------------------------------------------+
    | Camlp4                                                          |

--- a/src/lib/uTop.cppo.ml
+++ b/src/lib/uTop.cppo.ml
@@ -640,7 +640,7 @@ let () =
         let () =
           Printf.printf
             "Stashing %d entries in %s... "
-            (List.length entries)
+            (List.length entries / 2) (* because half are comments *)
             fname
         in
         let entries = List.rev entries in

--- a/src/lib/uTop.mli
+++ b/src/lib/uTop.mli
@@ -210,6 +210,15 @@ val history_file_max_entries : int option ref
       default) the maximum number of entries if [history] will be
       used. *)
 
+val stashable_session_history : LTerm_history.t
+  (** A history consisting only of expressions successfully evaluated
+   * during the current session. Because stashing is supposed to
+   * produce a valid OCaml file which will behave roughly the same as
+   * the console, it is best if this history never gets truncated, so
+   * its maximum size is set at [max_int]. While this will certainly
+   * lead to a slight memory leaking problem, UTop sessions are
+   * rarely long enough to make it a serious issue. *)
+
 (** {6 Console specific configuration} *)
 
 type profile = Dark | Light

--- a/src/lib/uTop.mli
+++ b/src/lib/uTop.mli
@@ -212,12 +212,12 @@ val history_file_max_entries : int option ref
 
 val stashable_session_history : LTerm_history.t
   (** A history consisting only of expressions successfully evaluated
-   * during the current session. Because stashing is supposed to
-   * produce a valid OCaml file which will behave roughly the same as
-   * the console, it is best if this history never gets truncated, so
-   * its maximum size is set at [max_int]. While this will certainly
-   * lead to a slight memory leaking problem, UTop sessions are
-   * rarely long enough to make it a serious issue. *)
+      during the current session. Because stashing is supposed to
+      produce a valid OCaml file which will behave roughly the same as
+      the console, it is best if this history never gets truncated, so
+      its maximum size is set at [max_int]. While this will certainly
+      lead to a slight memory leaking problem, UTop sessions are
+      rarely long enough to make it a serious issue. *)
 
 (** {6 Console specific configuration} *)
 

--- a/src/lib/uTop_main.cppo.ml
+++ b/src/lib/uTop_main.cppo.ml
@@ -182,7 +182,11 @@ class read_phrase ~term = object(self)
         try
           let result = parse_and_check input eos_is_error in
           return_value <- Some result;
-          LTerm_history.add UTop.history input;
+          ignore(match result with
+            | UTop.Value _, _ ->
+                LTerm_history.add UTop.history input;
+                ignore(LTerm_history.add UTop.stashable_session_history input)
+            | _, _ -> ());
           return result
         with UTop.Need_more ->
           (* Input not finished, continue. *)

--- a/src/lib/uTop_main.cppo.ml
+++ b/src/lib/uTop_main.cppo.ml
@@ -185,7 +185,6 @@ class read_phrase ~term = object(self)
           LTerm_history.add UTop.history input;
           ignore(match result with
             | UTop.Value _, _ ->
-                LTerm_history.add UTop.history input;
                 ignore(LTerm_history.add UTop.stashable_session_history input)
             | _, _ -> ());
           return result
@@ -671,6 +670,8 @@ let rec loop term =
            (* Get the string printed. *)
            Format.pp_print_flush pp ();
            let string = Buffer.contents buffer in
+           let string' = "(* " ^ (String.trim string) ^ " *)\n" in
+           let _ = LTerm_history.add UTop.stashable_session_history string' in
            match phrase with
              | Parsetree.Ptop_def _ ->
                  (* The string is an output phrase, colorize it. *)

--- a/src/lib/uTop_main.cppo.ml
+++ b/src/lib/uTop_main.cppo.ml
@@ -182,6 +182,7 @@ class read_phrase ~term = object(self)
         try
           let result = parse_and_check input eos_is_error in
           return_value <- Some result;
+          LTerm_history.add UTop.history input;
           ignore(match result with
             | UTop.Value _, _ ->
                 LTerm_history.add UTop.history input;


### PR DESCRIPTION
I frequently find myself putting a lot of work into a project with UTop and wishing to save that work without the tedium of manually rooting through the terminal history. This PR includes a `#utop_stash "filename"` directive which writes all of the valid toplevel expressions executed in the active session to a file. In order to accomplish this, it maintains a separate history which is never backed onto a file unless requested using the directive above, and contains only the toplevel expressions from the current session which compiled without errors.
