### PR TITLE
Handle the `Invalid_package_type` syntax error

### DIFF
--- a/src/lib/uTop.cppo.ml
+++ b/src/lib/uTop.cppo.ml
@@ -268,6 +268,11 @@ let parse_default parse str eos_is_error =
           Error ([mkloc loc],
                  Printf.sprintf "Error: broken invariant in parsetree: %s" s)
 #endif
+#if OCAML_VERSION >= (4, 03, 0)
+      | Syntaxerr.Invalid_package_type (loc, s) ->
+          Error ([mkloc loc],
+                 Printf.sprintf "Syntax error: invalid package type: %s" s)
+#endif
     end
     | Syntaxerr.Escape_error | Parsing.Parse_error ->
         Error ([mkloc (Location.curr lexbuf)],


### PR DESCRIPTION
When using OCaml 4.03, entering in utop

```OCaml
(module List: sig end);;
```
makes utop crashes with
```
Fatal error: exception File "src/lib/uTop.cppo.ml", line 246, characters 31-36: Pattern matching failed .   
```
The crash appears to stem from the new `Invalid_package_type` syntax error introduced in Ocaml 4.03 (for [PR#7097](http://caml.inria.fr/mantis/view.php?id=7097), [change entry](https://github.com/ocaml/ocaml/blob/trunk/Changes#L363)) . This pull request simply adds this case in the relevant pattern matching to fix this fatal error.