### PR TITLE
Stashing updated

### DIFF
--- a/src/lib/uTop.ml
+++ b/src/lib/uTop.ml
@@ -27,6 +27,11 @@ let history = LTerm_history.create []
 let history_file_name = ref (Some (Filename.concat LTerm_resources.home ".utop-history"))
 let history_file_max_size = ref None
 let history_file_max_entries = ref None
+let stashable_session_history =
+  (LTerm_history.create
+    ~max_size:max_int
+    ~max_entries:max_int
+    [])
 
 (* +-----------------------------------------------------------------+
    | Hooks                                                           |
@@ -537,6 +542,7 @@ utop defines the following directives:
 #help            : list all directives
 #utop_bindings   : list all the current key bindings
 #utop_macro      : display the currently recorded macro
+#utop_stash      : store all the valid commands from your current session in a file
 #topfind_log     : display messages recorded from findlib since the beginning of the session
 #topfind_verbose : enable/disable topfind verbosity
 
@@ -628,6 +634,34 @@ let () =
   Hashtbl.add Toploop.directive_table "pwd"
     (Toploop.Directive_none
        (fun () -> print_endline (Sys.getcwd ())))
+
+let () =
+  Hashtbl.add Toploop.directive_table "utop_stash"
+    (Toploop.Directive_string
+      (fun fname ->
+        let _ :: entries = LTerm_history.contents stashable_session_history in
+        (* getting and then reversing the entries instead of using
+           [LTerm_history.save] because the latter escapes newline characters *)
+        let () =
+          Printf.printf
+            "Stashing %d entries in %s... "
+            (List.length entries / 2) (* because half are comments *)
+            fname
+        in
+        let entries = List.rev entries in
+        try
+          let oc = open_out fname in
+          try
+            List.iter
+              (fun e ->
+                output_string oc (e ^ "\n"))
+              entries;
+            close_out oc;
+            Printf.printf "Done.\n";
+          with exn ->
+            close_out oc;
+            Printf.printf "Done.\n";
+        with exn -> Printf.printf "Error with file %s.\n" fname))
 
 (* +-----------------------------------------------------------------+
    | Camlp4                                                          |

--- a/src/lib/uTop.mli
+++ b/src/lib/uTop.mli
@@ -210,6 +210,15 @@ val history_file_max_entries : int option ref
       default) the maximum number of entries if [history] will be
       used. *)
 
+val stashable_session_history : LTerm_history.t
+  (** A history consisting only of expressions successfully evaluated
+      during the current session. Because stashing is supposed to
+      produce a valid OCaml file which will behave roughly the same as
+      the console, it is best if this history never gets truncated, so
+      its maximum size is set at [max_int]. While this will certainly
+      lead to a slight memory leaking problem, UTop sessions are
+      rarely long enough to make it a serious issue. *)
+
 (** {6 Console specific configuration} *)
 
 type profile = Dark | Light

--- a/src/lib/uTop.mli
+++ b/src/lib/uTop.mli
@@ -210,14 +210,13 @@ val history_file_max_entries : int option ref
       default) the maximum number of entries if [history] will be
       used. *)
 
-val stashable_session_history : LTerm_history.t
-  (** A history consisting only of expressions successfully evaluated
-      during the current session. Because stashing is supposed to
-      produce a valid OCaml file which will behave roughly the same as
-      the console, it is best if this history never gets truncated, so
-      its maximum size is set at [max_int]. While this will certainly
-      lead to a slight memory leaking problem, UTop sessions are
-      rarely long enough to make it a serious issue. *)
+val stashable_session_history : UTop_history.t
+  (** A history consisting of inputs and resulting values or errors of the
+      current session. Because stashing is supposed to produce a valid OCaml
+      file which will behave roughly the same as the console, it is best if
+      this history never gets truncated. While this will certainly lead to a
+      slight memory leaking problem, UTop sessions are rarely long enough to
+      make it a serious issue. *)
 
 (** {6 Console specific configuration} *)
 

--- a/src/lib/uTop_history.ml
+++ b/src/lib/uTop_history.ml
@@ -1,0 +1,70 @@
+(*
+ * uTop_history.ml
+ * -----------------
+ * Copyright : (c) 2017, Fabian Hemmer <copy@copy.sh>
+ * Licence   : BSD3
+ *
+ * This file is a part of utop.
+ *)
+
+type entry =
+  | Input of string
+  | Output of string
+  | Error of string
+  | Warnings of string
+  | Bad_input of string
+and t = entry list ref
+
+let create () : t =
+  ref []
+
+let contents (t : t) =
+  !t
+
+let strip_colors s =
+  let len = String.length s in
+  let find_escape offset =
+    try
+      let i = String.index_from s offset '\027' in
+      if i = len - 1 || s.[i + 1] <> '[' then
+        None
+      else
+        Some i
+    with
+    | Not_found -> None
+  in
+  let rec find_color_escapes offset =
+    match find_escape offset with
+    | None -> [offset, len]
+    | Some esc_offset ->
+      try
+        let i = String.index_from s esc_offset 'm' in
+        (offset, esc_offset) :: find_color_escapes (i + 1)
+      with
+      | Not_found -> [offset, len]
+  in
+  find_color_escapes 0
+    |> List.map (fun (i, j) -> String.sub s i (j - i))
+    |> String.concat ""
+
+let add history v =
+  history := v :: !history
+
+let add_input history input =
+  add history @@ Input (String.trim input)
+
+let add_output history output =
+  let output = String.trim output in
+  if output <> "" then (* directives produce empty output *)
+    add history @@ Output output
+
+let add_error history error =
+  add history @@ Error (strip_colors @@ String.trim error)
+
+let add_bad_input history input =
+  add history @@ Bad_input (String.trim input)
+
+let add_warnings history warnings =
+  let warnings = String.trim warnings in
+  if warnings <> "" then
+    add history @@ Warnings warnings

--- a/src/lib/uTop_history.mli
+++ b/src/lib/uTop_history.mli
@@ -1,0 +1,40 @@
+(*
+ * uTop_history.mli
+ * -------
+ * Copyright : (c) 2017, Fabian Hemmer <copy@copy.sh>
+ * Licence   : BSD3
+ *
+ * This file is a part of utop.
+ *)
+
+
+(** Type of a history entry *)
+type entry =
+  | Input of string
+  | Output of string
+  | Error of string
+  | Warnings of string
+  | Bad_input of string
+
+type t
+
+val create : unit -> t
+  (** Create a new, empty history *)
+
+val contents : t -> entry list
+  (** Get the contents of the given history *)
+
+val add_input : t -> string -> unit
+  (** Add an input *)
+
+val add_output : t -> string -> unit
+  (** Add an output *)
+
+val add_error : t -> string -> unit
+  (** Add an error *)
+
+val add_warnings : t -> string -> unit
+  (** Add a warning *)
+
+val add_bad_input : t -> string -> unit
+  (** Add an input that resulted in an error *)


### PR DESCRIPTION
I picked up @chrismamo1's progress and added the remaining bits:

- Stripping of colour escapes
- Separate inputs and outputs in the stashable history
- Another directive besides `#utop_stash`: `#utop_save`, which saves the session as if it was entered in a simplified prompt:

```
# let x = 5;;
val x : int = 5
# let y = 6;;
val y : int = 6
# x + y;;
- : int = 11
# x ^ y;;
Error: This expression has type int but an expression was expected of type
         string
# !@#$%;;
Error: Syntax error
```

Warnings are omitted currently, but I don't consider this a vital feature.