### PR TITLE
Bind expressions to _0, _1, etc.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 1.20 (in preparation)
 ---------------------
 
+* Add `-implicit-bindings` option to automatically bind expressions to names
+  `_0`, `_1` and so on. For example, `3 + 4;;` becomes `let _0 = 3 + 4;;`
+  (#161, #193, Fabian Hemmer)
 * Add tab completion for `#mod_use` (#181, Leonid Rozenberg)
 * Mention `#help` in `#utop_help` (#190, Fabian Hemmer)
 * Add `#utop_stash` and `#utop_save` to save the session to a file

--- a/src/lib/uTop.ml
+++ b/src/lib/uTop.ml
@@ -70,6 +70,7 @@ type syntax =
   | Camlp4r
 
 let hide_reserved, get_hide_reserved, set_hide_reserved = make_variable true
+let create_implicits, get_create_implicits, set_create_implicits = make_variable false
 let show_box, get_show_box, set_show_box = make_variable true
 let syntax, get_syntax, set_syntax = make_variable Normal
 let phrase_terminator, get_phrase_terminator, set_phrase_terminator = make_variable ";;"

--- a/src/lib/uTop.mli
+++ b/src/lib/uTop.mli
@@ -50,6 +50,24 @@ val get_hide_reserved : unit -> bool
 val set_hide_reserved : bool -> unit
   (** Modifies {!hide_reserved}. *)
 
+val create_implicits : bool signal
+  (** If [true] (not the default) expressions entered in the toplevel are
+      automatically bound, for example:
+
+      {[
+        # 3 + 4;;
+        _0 : int = 7
+        # _0 + 10;;
+        _1 : int = 17
+      ]}
+  *)
+
+val get_create_implicits : unit -> bool
+  (** Returns the value of {!create_implicits}. *)
+
+val set_create_implicits : bool -> unit
+  (** Modifies {!create_implicits}. *)
+
 val topfind_verbose : bool signal
   (** If [false] (the default) messages from findlib are hidden. This is only effective
       with findlib >= 1.4. *)


### PR DESCRIPTION
This rewrites toplevel expressions like `x;;` to `let _n = x;;`, for example:

```ocaml
# let x = 5;;
val x : int = 5
# x + 6;;
val _1 : int = 11
# _1 - 6;;
val _2 : int = 5
```

Only tested on 4.04. I think this is the right approach. The newly created bindings are not available in the output of `#utop_stash`, but I think this unavoidable.

Currently the binding (`val _1 : …`) only shows up if `-show-reserved` is passed. We could show `_n` when `n` is numeric even when reserved identifiers should be hidden.