### PR TITLE
Fix installation to handle utop.el too

### DIFF
--- a/jbuild
+++ b/jbuild
@@ -4,6 +4,10 @@
  ((section share)
   (files (utoprc-dark utoprc-light))))
 
+(install
+ ((section share_root)
+  (files ((src/top/utop.el as emacs/site-lisp/utop.el)))))
+
 (alias
  ((name examples)
   (deps (examples/custom-utop/myutop.bc


### PR DESCRIPTION
seems that was forgotten in the migration to jbuild. Unfortunately, this causes 'opam-user-setup' to break badly (at emacs startup, it finds the opam package, then breaks trying to load the file, and consequently doesn't load remaining modules)