### PR TITLE
Some random work I did on the emacs mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 _build/
 .merlin
 *.install
+*.elc

--- a/src/top/utop.el
+++ b/src/top/utop.el
@@ -244,7 +244,7 @@ list of 3 function symbols: (tuareg-symbol typerex-symbol caml-symbol)."
    ((eq major-mode 'caml-mode    ) (nth 2 choices))
    ((eq major-mode 'reason-mode  ) (nth 3 choices))
    (t (error (format "utop doesn't support the major mode \"%s\". It
-supports caml, tuareg and typerex modes by default. For other
+supports caml, tuareg, typerex and reason modes by default. For other
 modes you need to set these variables:
 
 - `utop-next-phrase-beginning'

--- a/src/top/utop.el
+++ b/src/top/utop.el
@@ -400,7 +400,7 @@ it is started."
      ('copy "You cannot edit the buffer while waiting for copy of last input")
      ('hist "You cannot edit the buffer while waiting for history"))))
 
-(defun utop-before-change (start stop)
+(defun utop-before-change (_start stop)
   (unless utop-inhibit-check
     (cond
      ((not (eq utop-state 'edit))
@@ -626,7 +626,7 @@ it is started."
          (minibuffer-hide-completions))
        (setq utop-completion nil)))))
 
-(defun utop-process-output (process output)
+(defun utop-process-output (_process output)
   "Process the output of utop"
   (with-current-buffer utop-buffer-name
     (utop-perform
@@ -871,7 +871,7 @@ defaults to 0."
     (unless (eq utop-state 'done)
       (utop-send-string (format "exit:%d\n" (or exit-code 0))))))
 
-(defun utop-sentinel (process msg)
+(defun utop-sentinel (_process _msg)
   "Callback for process' state change."
   (let ((buffer (get-buffer utop-buffer-name)))
     ;; Do nothing if the buffer does not exist anymore
@@ -948,7 +948,7 @@ defaults to 0."
       (setq packages (cdr packages))))
   (setq tabulated-list-entries (nreverse tabulated-list-entries)))
 
-(defun utop-package-printer (id cols)
+(defun utop-package-printer (_id cols)
   "Print one findlib package entry."
   (let ((width (cadr (elt tabulated-list-format 0))))
     (insert-text-button (elt cols 0)

--- a/src/top/utop.el
+++ b/src/top/utop.el
@@ -19,9 +19,7 @@
 
 (require 'easymenu)
 (require 'pcase)
-
-;; tabulated-list is a part of Emacs 24
-(require 'tabulated-list nil t)
+(require 'tabulated-list)
 
 ;; +-----------------------------------------------------------------+
 ;; | License                                                         |
@@ -267,54 +265,6 @@ modes you need to set these variables:
                           typerex-discover-phrase
                           caml-find-phrase
                           reason-discover-phrase))))
-
-;; +-----------------------------------------------------------------+
-;; | Compability with previous emacs version                         |
-;; +-----------------------------------------------------------------+
-
-(unless (featurep 'tabulated-list)
-  ;; tabulated-list.el is part of Emacs 24
-  ;; This is a thin layer building compability with previous versions
-  (defvar tabulated-list-format nil)
-  (defvar tabulated-list-sort-key nil)
-  (defvar tabulated-list-printer nil)
-  (defvar tabulated-list-revert-hook nil)
-  (defvar tabulated-list-entries nil)
-  (define-derived-mode tabulated-list-mode special-mode "Mini-tabulated list mode"
-    "Tabulated list"
-    (make-local-variable 'tabulated-list-format)
-    (make-local-variable 'tabulated-list-sort-key)
-    (make-local-variable 'tabulated-list-printer)
-    (set (make-local-variable 'revert-buffer-function) 'tabulated-list-revert)
-
-    (defun tabulated-list-init-header ()
-      (save-excursion
-        (let ((inhibit-read-only t))
-          (mapc
-           (lambda (entry)
-             (let* ((name (nth 0 entry))
-                    (size (length name))
-                    (padding (- (nth 1 entry) size)))
-               (insert name)
-               (insert-char ?\s padding)
-               )) tabulated-list-format)
-          (insert "\n"))))
-
-    (defun tabulated-list-print (dummy)
-      (save-excursion
-        (let ((inhibit-read-only t))
-          (mapc (lambda (entry)
-                  (goto-char (point-max))
-                  (apply tabulated-list-printer entry))
-                tabulated-list-entries))
-        t))
-
-    (defun tabulated-list-revert (ignore-auto noconfirm)
-      (let ((inhibit-read-only t))
-        (delete-region (point-min) (point-max))
-        (tabulated-list-init-header)
-        (tabulated-list-print t))))
-  )
 
 ;; +-----------------------------------------------------------------+
 ;; | Utils                                                           |

--- a/src/top/utop.el
+++ b/src/top/utop.el
@@ -1,4 +1,4 @@
-;;; utop.el --- Universal toplevel for OCaml
+;;; utop.el --- Universal toplevel for OCaml -*- lexical-binding: t -*-
 
 ;; Copyright: (c) 2011, Jeremie Dimino <jeremie@dimino.org>
 ;; Author: Jeremie Dimino <jeremie@dimino.org>

--- a/src/top/utop.el
+++ b/src/top/utop.el
@@ -18,6 +18,7 @@
 ;;; Code:
 
 (require 'easymenu)
+(require 'pcase)
 
 ;; tabulated-list is a part of Emacs 24
 (require 'tabulated-list nil t)
@@ -238,19 +239,20 @@ Caml toplevel")
 (defun utop-compat-resolve (choices)
   "Resolve a symbol based on the current major mode. CHOICES is a
 list of 3 function symbols: (tuareg-symbol typerex-symbol caml-symbol)."
-  (cond
-   ((eq major-mode 'tuareg-mode  ) (nth 0 choices))
-   ((eq major-mode 'typerex-mode ) (nth 1 choices))
-   ((eq major-mode 'caml-mode    ) (nth 2 choices))
-   ((eq major-mode 'reason-mode  ) (nth 3 choices))
-   (t (error (format "utop doesn't support the major mode \"%s\". It
+  (nth
+   (pcase major-mode
+     ('tuareg-mode 0)
+     ('typerex-mode 1)
+     ('caml-mode 2)
+     ('reason-mode 3)
+     (major-mode (error (format "utop doesn't support the major mode \"%s\". It
 supports caml, tuareg, typerex and reason modes by default. For other
 modes you need to set these variables:
 
 - `utop-next-phrase-beginning'
 - `utop-discover-phrase'
-"
-                     (symbol-name major-mode))))))
+" major-mode))))
+   choices))
 
 (defun utop-compat-next-phrase-beginning ()
   (funcall

--- a/src/top/utop.el
+++ b/src/top/utop.el
@@ -325,7 +325,7 @@ it is started."
                       (msg (concat ": " status-name "[" (int-to-string code) "]")))
                  (add-text-properties 0 (length msg) '(face bold) msg)
                  msg))
-              (else ": unknown"))))
+              (t ": unknown"))))
           (_ ": unknown"))))
 
 (defun utop-send-data (cmd)

--- a/src/top/utop.el
+++ b/src/top/utop.el
@@ -27,7 +27,7 @@
 ;; +-----------------------------------------------------------------+
 
 (defconst utop-license "BSD3"
-"Copyright (c) 2011, Jeremie Dimino <jeremie@dimino.org>
+  "Copyright (c) 2011, Jeremie Dimino <jeremie@dimino.org>
 All rights reserved.
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
@@ -285,34 +285,34 @@ modes you need to set these variables:
     (make-local-variable 'tabulated-list-printer)
     (set (make-local-variable 'revert-buffer-function) 'tabulated-list-revert)
 
-  (defun tabulated-list-init-header ()
-    (save-excursion
-      (let ((inhibit-read-only t))
-            (mapc
-             (lambda (entry)
-               (let* ((name (nth 0 entry))
-                      (size (length name))
-                      (padding (- (nth 1 entry) size)))
-                 (insert name)
-                 (insert-char ?\s padding)
-                 )) tabulated-list-format)
-            (insert "\n"))))
+    (defun tabulated-list-init-header ()
+      (save-excursion
+        (let ((inhibit-read-only t))
+          (mapc
+           (lambda (entry)
+             (let* ((name (nth 0 entry))
+                    (size (length name))
+                    (padding (- (nth 1 entry) size)))
+               (insert name)
+               (insert-char ?\s padding)
+               )) tabulated-list-format)
+          (insert "\n"))))
 
-  (defun tabulated-list-print (dummy)
-    (save-excursion
-      (let ((inhibit-read-only t))
-        (mapc (lambda (entry)
-                (goto-char (point-max))
-                (apply tabulated-list-printer entry))
-              tabulated-list-entries))
-      t))
+    (defun tabulated-list-print (dummy)
+      (save-excursion
+        (let ((inhibit-read-only t))
+          (mapc (lambda (entry)
+                  (goto-char (point-max))
+                  (apply tabulated-list-printer entry))
+                tabulated-list-entries))
+        t))
 
-  (defun tabulated-list-revert (ignore-auto noconfirm)
-    (let ((inhibit-read-only t))
-      (delete-region (point-min) (point-max))
-      (tabulated-list-init-header)
-      (tabulated-list-print t))))
-)
+    (defun tabulated-list-revert (ignore-auto noconfirm)
+      (let ((inhibit-read-only t))
+        (delete-region (point-min) (point-max))
+        (tabulated-list-init-header)
+        (tabulated-list-print t))))
+  )
 
 ;; +-----------------------------------------------------------------+
 ;; | Utils                                                           |
@@ -426,7 +426,7 @@ it is started."
             (left-word 1)
             (setq iterating (not (save-excursion
                                    (search-forward-regexp "[ \t\r\n].*" start-pos t)))))))
-          end-pos)))
+      end-pos)))
 
 (defun utop-ident-at-point ()
   "Identifier at point"
@@ -434,14 +434,14 @@ it is started."
         (end-pos (utop-ident-looking nil)))
     (buffer-substring-no-properties start-pos end-pos)))
 
-; Currently not working - the communication is asynchronous so how to
-; make sure without implementing another state that the type
-; information has been already printed?
+;; Currently not working - the communication is asynchronous so how to
+;; make sure without implementing another state that the type
+;; information has been already printed?
 (defun utop-type-at-point ()
   "Find type of an identifier at point from uTop"
-  (utop-eval-string (utop-ident-at-point))
-  ;  (utop-last-type)
-  )
+  (utop-eval-string (utop-ident-at-point)))
+;;  (utop-last-type)
+
 
 ;; +-----------------------------------------------------------------+
 ;; | Edition control                                                 |
@@ -651,16 +651,16 @@ it is started."
       (progn
         (cond
          ((eq utop-state 'copy)
-           (kill-new utop-pending-entry))
-          (t
-           (goto-char utop-prompt-max)
-           ;; Delete current input
-           (delete-region utop-prompt-max (point-max))
-           ;; Insert entry
-           (insert utop-pending-entry)))
-           ;; Resume edition
+          (kill-new utop-pending-entry))
+         (t
+          (goto-char utop-prompt-max)
+          ;; Delete current input
+          (delete-region utop-prompt-max (point-max))
+          ;; Insert entry
+          (insert utop-pending-entry)))
+        ;; Resume edition
         (utop-set-state 'edit)))
-      ;; We are at a bound of history
+     ;; We are at a bound of history
      ((string= command "history-bound")
       ;; Just resume edition
       (utop-set-state 'edit))
@@ -988,7 +988,7 @@ defaults to 0."
   ;; Get the list of packages
   (let* ((packages (utop-ocamlfind-list-packages))
          (max-name-length 0))
-        ;; Find the longest package name
+    ;; Find the longest package name
     (mapc
      (lambda (package)
        (setq max-name-length
@@ -1035,7 +1035,7 @@ defaults to 0."
     (utop-list-packages-mode)
     (utop-list-packages--refresh)
     (tabulated-list-print t)
-  (display-buffer buffer)))
+    (display-buffer buffer)))
 
 (defun utop-query-load-package-list ()
   "Load packages defined in utop-package-list buffer local variable."
@@ -1235,7 +1235,7 @@ Special keys for utop:
         (setq utop-command cmd)
         ;; Put it in utop mode
         (with-current-buffer buf (utop-mode)))))
-  buf))
+    buf))
 
 (provide 'utop-minor-mode)
 (provide 'utop)


### PR DESCRIPTION
I got rid of all the old Emacs workarounds. Emacs 24 is 5 years old, it's a
reasonable minimum. Also cleaned up a bunch of code that is more tersely done
with ocaml like pattern matching (pcase, which is available for emacs >= 24).

Finally, I've hacked together a simple company backend for utop completion. It's
not really ready for merging, but if there's interest I can work on it further.
For example: make the old completion still available for those who don't
use/like company, add type signatures to completions.

I've found it easier to implement the completion by adding a simple completion
command in utop itself. Although that might because I don't quite understand all
the details in the old command. Would appreciate some comments here.