### PR TITLE
Add support for ocaml 4.06

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,7 @@ env:
   global:
   - PACKAGE=utop
   matrix:
-  - OCAML_VERSION=4.02
-  - OCAML_VERSION=4.03
-  - OCAML_VERSION=4.04
+  - OCAML_VERSION=4.06
 os:
   - linux
   - osx

--- a/src/lib/uTop.ml
+++ b/src/lib/uTop.ml
@@ -180,7 +180,7 @@ let discard_formatters pps f =
   (* Output functions. *)
   let out_functions = {
     Format.out_string = (fun _ _ _ -> ()); out_flush = ignore;
-    out_newline = ignore; out_spaces = ignore;
+    out_newline = ignore; out_spaces = ignore; out_indent = ignore;
   } in
   (* Replace formatter functions. *)
   List.iter (fun pp -> Format.pp_set_formatter_out_functions pp out_functions) pps;

--- a/utop.opam
+++ b/utop.opam
@@ -20,4 +20,4 @@ depends: [
   "cppo"         {build & >= "1.1.2"}
   "jbuilder"     {build & >= "1.0+beta9"}
 ]
-available: [ ocaml-version >= "4.02.3" & ocaml-version < "4.06.0"]
+available: [ ocaml-version >= "4.06.0" & ocaml-version < "4.07.0"]


### PR DESCRIPTION
This PR weakens the version constraint to allow installation on ocaml 4.06. One tweak was made in `UTop.discard_formatters` in order to accommodate the new `out_indent` field in `Format.formatter_out_functions`.