### PR TITLE
Fix utop -vnum

### DIFF
--- a/src/lib/uTop_main.ml
+++ b/src/lib/uTop_main.ml
@@ -1175,7 +1175,8 @@ let print_version () =
   exit 0
 
 let print_version_num () =
-  Printf.printf "%s\n" UTop.version
+  Printf.printf "%s\n" UTop.version;
+  exit 0
 
 (* Config from command line *)
 let autoload = ref true


### PR DESCRIPTION
The handler for 'utop -vnum' failed to terminate after printing the
version number.