### PR TITLE
Fix utop-eval-phrase on recent tuareg-mode

### DIFF
--- a/src/top/utop.el
+++ b/src/top/utop.el
@@ -272,9 +272,19 @@ modes you need to set these variables:
 " major-mode))))
    choices))
 
+(defun utop-tuareg-next-phrase ()
+  "Move to the next phrase after point."
+  (let* ((pos (tuareg--after-double-colon))
+         (pos (if pos pos (point)))
+         (phrase (tuareg-discover-phrase pos)))
+    (when phrase
+      (goto-char (caddr phrase))
+      (tuareg--skip-double-colon)
+      (tuareg-skip-blank-and-comments))))
+
 (defun utop-compat-next-phrase-beginning ()
   (funcall
-   (utop-compat-resolve '(tuareg-next-phrase
+   (utop-compat-resolve '(utop-tuareg-next-phrase
                           typerex-skip-to-end-of-phrase
                           caml-skip-to-end-of-phrase
                           reason-next-phrase))))


### PR DESCRIPTION
tuareg-next-phrase was moved to tuareg_indent.el in
ocaml/tuareg@b40e733c1 and removed entirely in
ocaml/tuareg@b2ad75f3d5 (September 2017).

As a result, utop-eval-phrase crashes due to the missing function.

Instead, write a small function to move to the next phrase, similar to
the movement logic in tuareg-eval-phrase.